### PR TITLE
Replace File.exists? with File.exist? for Ruby 3.2

### DIFF
--- a/lib/configster/configster.rb
+++ b/lib/configster/configster.rb
@@ -41,7 +41,7 @@ module Configster
         Dir.glob(File.join(configster_config, "*.yml")).each do |file|
           @configster_config.merge!(YAML.load_file(file))
         end
-      elsif File.exists?(configster_config)
+      elsif File.exist?(configster_config)
         @configster_config.merge!(YAML.load_file(configster_config))
       else
         raise "Unable to locate #{configster_config}"


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.1 and [removed in Ruby 3.2](https://github.com/ruby/ruby/blob/v3_2_0/NEWS.md#removed-methods). This PR updates it to File.exist? to ensure compatibility with newer Ruby versions.

Let me know if anything else is needed.